### PR TITLE
chore: ignore saml key pairs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,5 @@ go.work.sum
 .env
 
 # keypairs
-saml.crt
-saml.key
+saml.crt*
+saml.key*


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Atualizados os padrões de exclusão para arquivos de chave, garantindo que todos os arquivos iniciados por `saml.crt` e `saml.key` sejam ignorados.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->